### PR TITLE
feat: support multiple generators

### DIFF
--- a/lib/@types/prisma-generator.ts
+++ b/lib/@types/prisma-generator.ts
@@ -1,5 +1,6 @@
 export interface PrismaGeneratorOptions {
   provider: string;
+  name?: string;
   output?: string;
   previewFeatures?: string[];
   engineType?: "library" | "binary";

--- a/lib/@types/prisma-generator.ts
+++ b/lib/@types/prisma-generator.ts
@@ -7,3 +7,7 @@ export interface PrismaGeneratorOptions {
   binaryTargets?: string[];
   [key: string]: string | string[] | undefined;
 }
+
+export type PrismaMultiGeneratorOptions = Array<
+  Omit<PrismaGeneratorOptions, "name"> & { name: string }
+>;

--- a/lib/@types/prisma-generator.ts
+++ b/lib/@types/prisma-generator.ts
@@ -5,4 +5,5 @@ export interface PrismaGeneratorOptions {
   previewFeatures?: string[];
   engineType?: "library" | "binary";
   binaryTargets?: string[];
+  [key: string]: string | string[] | undefined;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,11 +1,14 @@
 import { PrismaSchema } from "@/modules/PrismaSchema";
 
 import { PrismaDataSourceOptions } from "@/@types/prisma-datasource";
-import { PrismaGeneratorOptions } from "@/@types/prisma-generator";
+import {
+  PrismaGeneratorOptions,
+  PrismaMultiGeneratorOptions,
+} from "@/@types/prisma-generator";
 
 interface CreateSchemaOptions {
   datasource: PrismaDataSourceOptions;
-  generator: PrismaGeneratorOptions | PrismaGeneratorOptions[];
+  generator: PrismaGeneratorOptions | PrismaMultiGeneratorOptions;
 }
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,7 +5,7 @@ import { PrismaGeneratorOptions } from "@/@types/prisma-generator";
 
 interface CreateSchemaOptions {
   datasource: PrismaDataSourceOptions;
-  generator: PrismaGeneratorOptions;
+  generator: PrismaGeneratorOptions | PrismaGeneratorOptions[];
 }
 
 /**

--- a/lib/modules/PrismaScalarField.ts
+++ b/lib/modules/PrismaScalarField.ts
@@ -50,7 +50,7 @@ export class PrismaScalarField {
     switch (typeof defaultValue) {
       case "object":
         const [prismaFunc] =
-          Object.entries(defaultValue).find(([_key, value]) => value) || [];
+          Object.entries(defaultValue).find(([, value]) => value) || [];
         setDefaultValue(`${prismaFunc}()`);
         break;
       case "string":

--- a/lib/modules/PrismaSchema.ts
+++ b/lib/modules/PrismaSchema.ts
@@ -43,7 +43,11 @@ export class PrismaSchema {
 
     return generators
       .map(({ name = "client", ...generator }) =>
-        parseKeyValueBlock("generator", name, Object.entries(generator))
+        parseKeyValueBlock(
+          "generator",
+          name,
+          Object.entries(generator) as [string, string | string[]][]
+        )
       )
       .join("\n\n");
   }

--- a/lib/modules/PrismaSchema.ts
+++ b/lib/modules/PrismaSchema.ts
@@ -13,7 +13,9 @@ export class PrismaSchema {
 
   constructor(
     private readonly datasource: PrismaDataSourceOptions,
-    private readonly generator: PrismaGeneratorOptions
+    private readonly generator:
+      | PrismaGeneratorOptions
+      | PrismaGeneratorOptions[]
   ) {}
 
   /**
@@ -35,11 +37,15 @@ export class PrismaSchema {
    * @returns A string representing the generator block.
    */
   private parseGenerator() {
-    return parseKeyValueBlock(
-      "generator",
-      "client",
-      Object.entries(this.generator)
-    );
+    const generators = Array.isArray(this.generator)
+      ? this.generator
+      : [this.generator];
+
+    return generators
+      .map(({ name = "client", ...generator }) =>
+        parseKeyValueBlock("generator", name, Object.entries(generator))
+      )
+      .join("\n\n");
   }
 
   /**

--- a/lib/modules/PrismaSchema.ts
+++ b/lib/modules/PrismaSchema.ts
@@ -5,7 +5,10 @@ import { exportSchema } from "@/util/export";
 import { parseKeyValueBlock } from "@/util/blocks";
 
 import { PrismaDataSourceOptions } from "@/@types/prisma-datasource";
-import { PrismaGeneratorOptions } from "@/@types/prisma-generator";
+import {
+  PrismaGeneratorOptions,
+  PrismaMultiGeneratorOptions,
+} from "@/@types/prisma-generator";
 
 export class PrismaSchema {
   private enums: Map<string, PrismaEnum> = new Map();
@@ -15,7 +18,7 @@ export class PrismaSchema {
     private readonly datasource: PrismaDataSourceOptions,
     private readonly generator:
       | PrismaGeneratorOptions
-      | PrismaGeneratorOptions[]
+      | PrismaMultiGeneratorOptions
   ) {}
 
   /**

--- a/lib/util/blocks.ts
+++ b/lib/util/blocks.ts
@@ -8,7 +8,7 @@
 export const parseKeyValueBlock = (
   keyword: string,
   name: string,
-  entries: [string, string | { env: string }][]
+  entries: [string, string | string[] | { env: string }][]
 ) => {
   const tokenPadding = Math.max(...entries.map(([key]) => key.length));
   const body = entries


### PR DESCRIPTION
I have a requirement to use https://github.com/notiz-dev/prisma-dbml-generator with our schema; this PR attempts to add support for multiple generator configs, with arbitrary values to hopefully open up the config to any generator someone may want to add.