### PR TITLE
Updated yarn instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 To install Schemix, simply use your favourite Node.js package manager.
 
 ```bash
-yarn install schemix
+yarn add schemix
 ```
 
 ```bash


### PR DESCRIPTION
`yarn install schemix` gives an error for newer version of yarn :

```
error `install` has been replaced with `add` to add new dependencies. Run "yarn add schemix" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

This PR aims to fix it in the docs !