### PR TITLE
feat: support recursive file search

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -14,22 +14,16 @@ generator client {
   provider = "prisma-client-js"
 }
 
+generator prismaThirdPartyGenerator {
+  provider               = "prisma-includes-generator"
+  seperateRelationFields = true
+}
+
 enum Status {
   PENDING
   LIVE
   DELETED
   REMOVED
-}
-
-model User {
-  id              String   @id @default(uuid()) @database.Uuid
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  posts           Post[]
-  friends         User[]   @relation(name: "friends")
-  friendRelations User[]   @relation(name: "friends")
-  email           String
-  fullName        String
 }
 
 model Post {
@@ -38,7 +32,29 @@ model Post {
   updatedAt DateTime @updatedAt
   status    Status
   text      String
-  author    User     @relation(fields: [authorId], references: [id])
+  author    User     @relation(fields: [authorId], references: [email])
   authorId  String
 }
+
+model User {
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  posts           Post[]
+  auth            Auth?
+  friends         User[]   @relation(name: "friends")
+  friendRelations User[]   @relation(name: "friends")
+  email           String
+  fullName        String
+
+  @@id([email])
+}
+
+model Auth {
+  id     String @id @default(uuid()) @database.Uuid
+  hash   String
+  salt   String
+  user   User   @relation(fields: [userId], references: [email])
+  userId String
+}
+
 ```

--- a/example/models/User.model.ts
+++ b/example/models/User.model.ts
@@ -1,11 +1,13 @@
 import { createModel } from "../../dist";
 import DateTimeMixin from "../mixins/DateTime.mixin";
+import AuthModel from "./auth/Auth.model";
 import PostModel from "./Post.model";
 
 export default createModel((UserModel) => {
   UserModel
     .mixin(DateTimeMixin)
     .relation("posts", PostModel, { list: true })
+    .relation("auth", AuthModel, { optional: true })
     .relation("friends", UserModel, { list: true, name: "friends" })
     .relation("friendRelations", UserModel, { list: true, name: "friends" })
     .string("email")

--- a/example/models/auth/Auth.model.ts
+++ b/example/models/auth/Auth.model.ts
@@ -1,0 +1,12 @@
+import { createModel } from "../../../dist";
+import UUIDMixin from "../../mixins/UUID.mixin";
+import UserModel from "../../models/User.model";
+
+export default createModel((AuthModel) => {
+  AuthModel
+    .mixin(UUIDMixin)
+    .string("hash")
+    .string("salt")
+    .relation("user", UserModel, { fields: ["userId"], references: ["email"] })
+    .string("userId", { unique: true });
+});

--- a/example/schema.prisma
+++ b/example/schema.prisma
@@ -19,18 +19,6 @@ enum Status {
   REMOVED
 }
 
-model User {
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  posts           Post[]
-  friends         User[]   @relation(name: "friends")
-  friendRelations User[]   @relation(name: "friends")
-  email           String
-  fullName        String
-
-  @@id([email])
-}
-
 model Post {
   id        String   @id @default(uuid()) @database.Uuid
   createdAt DateTime @default(now())
@@ -39,4 +27,25 @@ model Post {
   text      String
   author    User     @relation(fields: [authorId], references: [email])
   authorId  String
+}
+
+model User {
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  posts           Post[]
+  auth            Auth?
+  friends         User[]   @relation(name: "friends")
+  friendRelations User[]   @relation(name: "friends")
+  email           String
+  fullName        String
+
+  @@id([email])
+}
+
+model Auth {
+  id     String @id @default(uuid()) @database.Uuid
+  hash   String
+  salt   String
+  user   User   @relation(fields: [userId], references: [email])
+  userId String @unique
 }

--- a/lib/util/import.ts
+++ b/lib/util/import.ts
@@ -41,6 +41,6 @@ const getAllFilesRecursively = async (
 
 export const importAllFiles = async (basePath: string, folderName: string) => {
   return getAllFilesRecursively(basePath, folderName)
-    .then((files) => files.map((fileName) => import(fileName)))
+    .then((files) => Promise.all(files.map((fileName) => import(fileName))))
     .catch(() => void 0);
 };

--- a/lib/util/import.ts
+++ b/lib/util/import.ts
@@ -42,5 +42,5 @@ const getAllFilesRecursively = async (
 export const importAllFiles = async (basePath: string, folderName: string) => {
   return getAllFilesRecursively(basePath, folderName)
     .then((files) => Promise.all(files.map((fileName) => import(fileName))))
-    .catch(() => void 0);
+    .catch(console.error);
 };

--- a/lib/util/import.ts
+++ b/lib/util/import.ts
@@ -1,15 +1,46 @@
-import { readdir } from "fs/promises";
+import { readdir, stat } from "fs/promises";
 import { join } from "path";
 
-export const importAllFiles = async (basePath: string, folderName: string) => {
-  const directoryPath = join(basePath, folderName);
-  return readdir(directoryPath)
-    .then((fileNames) => {
-      const promises = fileNames.map(
-        (fileName) => import(join(basePath, folderName, fileName))
-      );
+const isDirectory = async (fullPath: string): Promise<boolean> => {
+  return (await stat(fullPath)).isDirectory();
+};
 
-      return Promise.all(promises);
-    })
+async function asyncFilter<T>(
+  arr: T[],
+  predicate: (value: T) => Promise<boolean>
+): Promise<T[]> {
+  const results = await Promise.all(arr.map(predicate));
+
+  return arr.filter((_, index) => results[index]);
+}
+
+const getAllFilesRecursively = async (
+  basePath: string,
+  folderName: string
+): Promise<string[]> => {
+  const directoryPath = join(basePath, folderName);
+
+  const fileNames = await readdir(directoryPath);
+  const directories = await asyncFilter(fileNames, async (fileName) =>
+    isDirectory(join(directoryPath, fileName))
+  );
+  const files = fileNames
+    .filter((fileName) => !directories.includes(fileName))
+    .map((file) => join(directoryPath, file));
+
+  const filesInDirectories = (
+    await Promise.all(
+      directories.map((directory) =>
+        getAllFilesRecursively(directoryPath, directory)
+      )
+    )
+  ).flat();
+
+  return [...filesInDirectories, ...files];
+};
+
+export const importAllFiles = async (basePath: string, folderName: string) => {
+  return getAllFilesRecursively(basePath, folderName)
+    .then((files) => files.map((fileName) => import(fileName)))
     .catch(() => void 0);
 };


### PR DESCRIPTION
This PR supports putting enums / mixins / models in nested folders. This is particularly helpful to separate the models by domain folders:
```
- models
    - auth
        - Account.model.ts
        - VerificationToken.model.ts
    - order
        - Order.model.ts
        - OrderItem.model.ts  
```