### PR TITLE
Allow unique enum fields

### DIFF
--- a/lib/@types/prisma-type-options.ts
+++ b/lib/@types/prisma-type-options.ts
@@ -144,11 +144,13 @@ export type EnumFieldOptions = (
       default?: string;
       list?: never;
       optional?: true;
+      unique?: true;
     }
   | {
       default?: never;
       list?: true;
       optional?: never;
+      unique?: never;
     }
 ) &
   DefaultFieldOptions;

--- a/lib/modules/PrismaEnumField.ts
+++ b/lib/modules/PrismaEnumField.ts
@@ -24,6 +24,11 @@ export class PrismaEnumField {
     return this;
   }
 
+  public setUnique() {
+    this.attributes.set("unique", "@unique");
+    return this;
+  }
+
   public setDefault(defaultValue: string) {
     this.attributes.set("default", `@default(${defaultValue})`);
     return this;

--- a/lib/util/options.ts
+++ b/lib/util/options.ts
@@ -72,6 +72,7 @@ export const handleEnumOptions = <T extends EnumFieldOptions>(
     default: "setDefault",
     optional: "setOptional",
     list: "setList",
+    unique: "setUnique",
     map: "mapTo",
     raw: "setRawAttributes",
   };


### PR DESCRIPTION
Fixes https://github.com/ridafkih/schemix/issues/21 

This adds the `unique` option to `EnumFieldOptions` and the public `setUnique` method on `PrismaEnumField`. This allows enum fields to be declared as unique via the updated `handleEnumOptions` method.

**There are no tests, so please double check before merging.**