### PR TITLE
Add composite uniqueness

### DIFF
--- a/lib/@types/prisma-type-options.ts
+++ b/lib/@types/prisma-type-options.ts
@@ -168,6 +168,16 @@ export type CompositeIDFieldOptions = {
   map?: string;
 };
 
+export type CompositeUniqueFields = string[]
+export type CompositeUniqueOptions = {
+  fields: CompositeUniqueFields;
+  map?: string;
+}
+
+export type CompositeUniqueFieldOptions = 
+  | CompositeUniqueOptions 
+  | CompositeUniqueFields;
+
 export type ModelMapOptions = {
   name: string;
 } | string;

--- a/lib/modules/PrismaModel.ts
+++ b/lib/modules/PrismaModel.ts
@@ -6,6 +6,7 @@ import { PrismaRelationalField } from "@/modules/PrismaRelationalField";
 
 import {
   buildCompositeId,
+  buildCompositeUnique,
   buildModelMap,
   handleEnumOptions,
   handleRelationalOptions,
@@ -17,6 +18,7 @@ import { PrismaFieldTypeName } from "@/@types/prisma-field";
 import {
   BooleanFieldOptions,
   CompositeIDFieldOptions,
+  CompositeUniqueFieldOptions,
   DateTimeFieldOptions,
   DecimalFieldOptions,
   EnumFieldOptions,
@@ -101,6 +103,11 @@ export class PrismaModel {
 
   public id(options: CompositeIDFieldOptions) {
     this.raw(buildCompositeId(options));
+    return this;
+  }
+
+  public unique(options: CompositeUniqueFieldOptions) {
+    this.raw(buildCompositeUnique(options));
     return this;
   }
 

--- a/lib/util/options.ts
+++ b/lib/util/options.ts
@@ -4,6 +4,8 @@ import { PrismaRelationalField } from "@/modules/PrismaRelationalField";
 
 import {
   CompositeIDFieldOptions,
+  CompositeUniqueFieldOptions,
+  CompositeUniqueOptions,
   EnumFieldOptions,
   FieldOptions,
   ModelMapOptions,
@@ -94,6 +96,25 @@ export const buildCompositeId = (options: CompositeIDFieldOptions) => {
 
   return `@@id(${parsedArguments})`;
 };
+
+const isCompositeUniqueOptions = (options: CompositeUniqueFieldOptions): options is CompositeUniqueOptions => typeof options === "object"
+export const buildCompositeUnique = (options: CompositeUniqueFieldOptions) => {
+  if (isCompositeUniqueOptions(options)) {
+    const fields = `[${options.fields.join(", ")}]`;
+    const args: string[] = [fields]
+    if (options.map) {
+      args.push(`map: ${options.map}`);
+    }
+    const parsedArguments: string = args
+    .join(", ");
+    return `@@unique(${parsedArguments})`;
+  } else {
+    return `@@unique([${options.join(", ")}])`;
+  }
+
+  
+  
+}
 
 export const buildModelMap = (options: ModelMapOptions) => {
   const name = typeof options === 'string' ? options : options.name;


### PR DESCRIPTION
Fixes https://github.com/ridafkih/schemix/issues/15

Like the `buildCompositeId`, this implements `buildCompositeUnique`.

It accepts either an array of strings (fields), e.g. `["fieldA", "fieldB"]` or an options object, e.g.
```ts
{
  fields: ["fieldA", "fieldB"],
  map: "field_A_field_B_uniqueness_constraint",  <--- optional
}
```

This will generate
```
@@unique([fieldA, fieldB])
```
and
```
@@unique([fieldA, fieldB], map: "field_A_field_B_uniqueness_constraint")
```
respectively.

**There are no tests, so please double check before merging.**