### PR TITLE
fix: import all mixins after models and enums

### DIFF
--- a/example/mixins/Author.mixin.ts
+++ b/example/mixins/Author.mixin.ts
@@ -1,0 +1,8 @@
+import { createMixin } from "../../dist";
+import UserModel from "../models/User.model";
+
+export default createMixin((AuthorMixin) => {
+  AuthorMixin
+    .relation("author", UserModel, { fields: ["authorId"], references: ["email"], })
+    .string("authorId");
+});

--- a/example/models/Post.model.ts
+++ b/example/models/Post.model.ts
@@ -1,8 +1,8 @@
 import { createModel } from "../../dist";
+import AuthorMixin from "../mixins/Author.mixin";
 import StatusEnum from "../enums/Status.enum";
 import DateTimeMixin from "../mixins/DateTime.mixin";
 import UUIDMixin from "../mixins/UUID.mixin";
-import UserModel from "./User.model";
 
 export default createModel((PostModel) => {
   PostModel
@@ -10,7 +10,6 @@ export default createModel((PostModel) => {
     .mixin(DateTimeMixin)
     .enum("status", StatusEnum)
     .string("text")
-    .relation("author", UserModel, { fields: ["authorId"], references: ["email"] })
-    .string("authorId")
+    .mixin(AuthorMixin)
     .map({ name: "post" });
 })

--- a/lib/modules/PrismaSchema.ts
+++ b/lib/modules/PrismaSchema.ts
@@ -95,8 +95,8 @@ export class PrismaSchema {
   public toString(): Promise<string> {
     return new Promise(async (resolve) => {
       await importAllFiles(this.basePath, "enums");
-      await importAllFiles(this.basePath, "mixins");
       await importAllFiles(this.basePath, "models");
+      await importAllFiles(this.basePath, "mixins");
 
       setTimeout(() => {
         const models = [


### PR DESCRIPTION
Addressed issue #33 by @Daidalos117 in which mixins containing relations did not work. 

This simply moves registration for mixins after enums and models, and introduces the change to the `example/` folder.