### PR TITLE
allow mixins to populate before adding to schema

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,14 @@
     "plugin:prettier/recommended"
   ],
   "plugins": ["@typescript-eslint"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parserOptions": {
+        "project": ["./tsconfig.json", "./tests/tsconfig.json"]
+      }
+    }
+  ],
   "env": {
     "browser": true,
     "es6": true,

--- a/lib/modules/PrismaModel.ts
+++ b/lib/modules/PrismaModel.ts
@@ -119,9 +119,12 @@ export class PrismaModel {
   }
 
   public mixin(model: PrismaModel) {
-    [...model.fields.entries()].map(([key, value]) =>
-      this.fields.set(key, value)
-    );
+    setImmediate(() => {
+      [...model.fields.entries()].map(([key, value]) =>
+        this.fields.set(key, value)
+      );
+    });
+
     return this;
   }
 

--- a/lib/modules/PrismaSchema.ts
+++ b/lib/modules/PrismaSchema.ts
@@ -109,7 +109,7 @@ export class PrismaSchema {
         await importAllFiles(this.basePath, "mixins");
       }
 
-      setTimeout(() => {
+      process.nextTick(() => {
         const models = [
           this.parseDataSource(),
           this.parseGenerator(),
@@ -121,7 +121,7 @@ export class PrismaSchema {
           models.map((model) => model.toString()).join("\n\n") + "\n";
 
         resolve(schemaString);
-      }, 0);
+      });
     });
   }
 

--- a/lib/util/create.ts
+++ b/lib/util/create.ts
@@ -20,13 +20,13 @@ export function createModel(
 
   if (typeof param1 === "string" && typeof param2 === "function") {
     const model = schema.createModel(param1);
-    setTimeout(param2, 0, model);
+    setImmediate(param2, model);
     return model;
   }
 
   if (typeof param1 === "function" && !param2) {
     const model = schema.createModel(getCallerFileName());
-    setTimeout(param1, 0, model);
+    setImmediate(param1, model);
     return model;
   }
 }
@@ -46,13 +46,13 @@ export function createEnum(
 
   if (typeof param1 === "string" && typeof param2 === "function") {
     const model = schema.createEnum(param1);
-    setTimeout(param2, 0, model);
+    setImmediate(param2, model);
     return model;
   }
 
   if (typeof param1 === "function" && !param2) {
     const model = schema.createEnum(getCallerFileName());
-    setTimeout(param1, 0, model);
+    setImmediate(param1, model);
     return model;
   }
 }
@@ -63,6 +63,6 @@ export function createMixin(
   if (!schema) throw Error("Schema was not initialized.");
 
   const model = schema.createMixin();
-  setTimeout(callback, 0, model);
+  process.nextTick(callback, model);
   return model;
 }

--- a/tests/__snapshots__/index.spec.ts.snap
+++ b/tests/__snapshots__/index.spec.ts.snap
@@ -17,19 +17,19 @@ enum UserStatus {
 }
 
 model Post {
+  content   String
+  deleted   Boolean
   id        String   @default(uuid()) @id
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  content   String
-  deleted   Boolean
 }
 
 model User {
+  status    UserStatus
+  posts     Post[]
   id        String     @default(uuid()) @id
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
-  status    UserStatus
-  posts     Post[]
 }
 "
 `;

--- a/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
@@ -92,6 +92,16 @@ exports[`PrismaModel > Should support adding fields 1`] = `
 `;
 
 exports[`PrismaModel > Should support adding mixins > model User {
+  email       String
+  phoneNumber String
+} 1`] = `
+"model User {
+  email       String
+  phoneNumber String
+}"
+`;
+
+exports[`PrismaModel > Should support adding mixins > model User {
   id          String @default(uuid()) @id
   email       String
   phoneNumber String


### PR DESCRIPTION
This pushes the addition of mixins prior to populating the schema to allow them to propagate.

Meant to address #40 by @Daidalos117.