### PR TITLE
Built project support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,14 @@
     "plugin:prettier/recommended"
   ],
   "plugins": ["@typescript-eslint"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "parserOptions": {
+        "project": ["./tsconfig.json", "./tests/tsconfig.json"]
+      }
+    }
+  ],
   "env": {
     "browser": true,
     "es6": true,

--- a/lib/util/import.ts
+++ b/lib/util/import.ts
@@ -39,8 +39,22 @@ const getAllFilesRecursively = async (
   return [...filesInDirectories, ...files];
 };
 
+const importFilteredFiles = (filePaths: string[]): Promise<unknown>[] => {
+  return filePaths.reduce((accumulator: Promise<unknown>[], filePath) => {
+    if (
+      filePath.endsWith(".d.ts.map") ||
+      filePath.endsWith(".d.ts") ||
+      filePath.endsWith(".js.map")
+    )
+      return accumulator;
+
+    accumulator.push(import(filePath));
+    return accumulator;
+  }, []);
+};
+
 export const importAllFiles = async (basePath: string, folderName: string) => {
   return getAllFilesRecursively(basePath, folderName)
-    .then((files) => Promise.all(files.map((fileName) => import(fileName))))
+    .then((files) => Promise.all(importFilteredFiles(files)))
     .catch(console.error);
 };


### PR DESCRIPTION
Filters out `.d.ts`, `.d.ts.map`, and `.js.map` files in order to allow for built projects to run! This makes it so that `ts-node` is no longer a hard requirement.