### PR TITLE
fix mixins when interfacing directly with `PrismaModel`

### DIFF
--- a/examples/programmatic-usage/routes/model.ts
+++ b/examples/programmatic-usage/routes/model.ts
@@ -25,9 +25,11 @@ export default route({
         model[type](name);
       }
 
+      const asString = await model.toString();
+      
       return {
         status: 200,
-        body: model.toString(),
+        body: asString,
       };
     },
   },

--- a/lib/modules/PrismaModel.ts
+++ b/lib/modules/PrismaModel.ts
@@ -143,8 +143,12 @@ export class PrismaModel {
     return clone;
   }
 
-  public toString() {
-    return [`model ${this.name} {`, this.parseFields(), "}"].join("\n");
+  public toString(): Promise<string> {
+    return new Promise((resolve) => {
+      setImmediate(() => {
+        resolve([`model ${this.name} {`, this.parseFields(), "}"].join("\n"));
+      });
+    });
   }
 
   private createRelation(

--- a/lib/modules/PrismaSchema.ts
+++ b/lib/modules/PrismaSchema.ts
@@ -117,10 +117,12 @@ export class PrismaSchema {
           ...this.models.values(),
         ];
 
-        const schemaString =
-          models.map((model) => model.toString()).join("\n\n") + "\n";
-
-        resolve(schemaString);
+        Promise.all(models.map((model) => model.toString())).then(
+          (stringModels) => {
+            const schemaString = stringModels.join("\n\n") + "\n";
+            resolve(schemaString);
+          }
+        );
       });
     });
   }

--- a/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
@@ -94,6 +94,18 @@ exports[`PrismaModel > Should support adding fields 1`] = `
 exports[`PrismaModel > Should support adding mixins > model User {
   email       String
   phoneNumber String
+  id          String @default(uuid()) @id
+} 1`] = `
+"model User {
+  email       String
+  phoneNumber String
+  id          String @default(uuid()) @id
+}"
+`;
+
+exports[`PrismaModel > Should support adding mixins > model User {
+  email       String
+  phoneNumber String
 } 1`] = `
 "model User {
   email       String


### PR DESCRIPTION
This should solve a regression caused by a fix that was released in order to support relations within mixins.

The change is breaking, as it makes the `PrismaModel#toString` function asynchronous. So this will likely be in release `v1.8.0`.  @efreila thank you for raising the issue a la #43.
