### PR TITLE
match both ticks when getting filename

### DIFF
--- a/lib/util/stack.ts
+++ b/lib/util/stack.ts
@@ -10,7 +10,7 @@ export const getCallerFileName = () => {
   const { stack } = grabber;
   Grabber.prepareStackTrace = undefined;
 
-  const pathSegments = stack?.[2].getFileName().split("/");
+  const pathSegments = stack?.[2].getFileName().split(/[/\\]/);
   const [fileName] = pathSegments[pathSegments.length - 1].split(".");
 
   return fileName;


### PR DESCRIPTION
This pull request is intended to fix file paths on Windows machines as per #46.