### PR TITLE
[WIP] feat: prisma enum from JS enum

### DIFF
--- a/examples/standard-usage/enums/UserType.enum.ts
+++ b/examples/standard-usage/enums/UserType.enum.ts
@@ -1,0 +1,10 @@
+import { createEnum } from "../../../dist";
+
+export enum UserType {
+  USER= 'USER',
+  SUPERUSER = 'SUPERUSER'
+}
+
+export default createEnum((UserTypeEnum) => {
+  UserTypeEnum.fromJSEnum(UserType);
+})

--- a/examples/standard-usage/models/User.model.ts
+++ b/examples/standard-usage/models/User.model.ts
@@ -2,6 +2,8 @@ import { createModel } from "../../../dist";
 import DateTimeMixin from "../mixins/DateTime.mixin";
 import AuthModel from "./auth/Auth.model";
 import PostModel from "./Post.model";
+import UserTypeEnum, {UserType} from "../enums/UserType.enum";
+
 
 export default createModel((UserModel) => {
   UserModel
@@ -12,6 +14,8 @@ export default createModel((UserModel) => {
     .relation("friendRelations", UserModel, { list: true, name: "friends" })
     .string("email")
     .string("fullName")
+    .enum("type", UserTypeEnum, {default: UserType.USER})
+
     .map("user")
     .id({ fields: ["email"] });
 })

--- a/examples/standard-usage/schema.prisma
+++ b/examples/standard-usage/schema.prisma
@@ -19,12 +19,17 @@ enum Status {
   REMOVED
 }
 
+enum UserType {
+  USER
+  SUPERUSER
+}
+
 model Post {
+  status    Status
+  text      String
   id        String   @id @default(uuid()) @database.Uuid
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  status    Status
-  text      String
   author    User     @relation(fields: [authorId], references: [email])
   authorId  String
 
@@ -32,23 +37,24 @@ model Post {
 }
 
 model User {
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
   posts           Post[]
   auth            Auth?
   friends         User[]   @relation(name: "friends")
   friendRelations User[]   @relation(name: "friends")
   email           String
   fullName        String
+  type            UserType @default(USER)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@map("user")
   @@id([email])
 }
 
 model Auth {
-  id     String @id @default(uuid()) @database.Uuid
   hash   String
   salt   String
   user   User   @relation(fields: [userId], references: [email])
   userId String @unique
+  id     String @id @default(uuid()) @database.Uuid
 }

--- a/lib/modules/PrismaEnum.ts
+++ b/lib/modules/PrismaEnum.ts
@@ -1,4 +1,6 @@
-import { PrismaEnumOptions } from "typings/prisma-enum";
+import { PrismaEnumOptions, Enum} from "typings/prisma-enum";
+
+
 
 export class PrismaEnum {
   private enumMap: Map<string, string | undefined> = new Map();
@@ -7,6 +9,17 @@ export class PrismaEnum {
 
   public addValue(value: string, options?: PrismaEnumOptions) {
     this.enumMap.set(value, options?.map);
+    return this;
+  }
+
+  public fromJSEnum<T extends Enum<T>>(
+    enumLike: T,
+    options?: PrismaEnumOptions
+  ) {
+    const values = Object.values(enumLike);
+    values.forEach((value) => {
+      this.enumMap.set(value, options?.map);
+    });
     return this;
   }
 

--- a/lib/typings/prisma-enum.ts
+++ b/lib/typings/prisma-enum.ts
@@ -1,3 +1,5 @@
 export interface PrismaEnumOptions {
   map?: string;
 }
+
+export type Enum<E> = Record<keyof E, number | string> & { [k: number]: string };


### PR DESCRIPTION
This is proposed functionality for importing TS/JS enums into the schemix/prisma. We can do this even now, but it would be nice if the library support this way out of the box.
IMHO it should be preferred way to import JS enums, because it has numerous advantages. 

- using enum anywhere
- using default value for column from enum 

Maybe better safety could be implemented because of this, not really sure for now. What do you think?