### PR TITLE
fix: keep the fields order same as the source

### DIFF
--- a/lib/modules/PrismaModel.ts
+++ b/lib/modules/PrismaModel.ts
@@ -159,7 +159,7 @@ export class PrismaModel {
     if (!model.name) return this;
     const field = new PrismaRelationalField(fieldName, model.name);
     handleRelationalOptions(field, options);
-    this.fields.set(fieldName, field);
+    setImmediate(() => this.fields.set(fieldName, field));
     return this;
   }
 
@@ -170,7 +170,7 @@ export class PrismaModel {
   ) {
     const field = new PrismaEnumField(fieldName, type);
     handleEnumOptions(field, options);
-    this.fields.set(fieldName, field);
+    setImmediate(() => this.fields.set(fieldName, field));
     return this;
   }
 
@@ -181,7 +181,7 @@ export class PrismaModel {
   ) {
     const field = new PrismaScalarField(fieldName, type);
     handleScalarOptions(field, options);
-    this.fields.set(fieldName, field);
+    setImmediate(() => this.fields.set(fieldName, field));
     return this;
   }
 

--- a/tests/__snapshots__/index.spec.ts.snap
+++ b/tests/__snapshots__/index.spec.ts.snap
@@ -17,19 +17,19 @@ enum UserStatus {
 }
 
 model Post {
-  content   String
-  deleted   Boolean
   id        String   @default(uuid()) @id
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  content   String
+  deleted   Boolean
 }
 
 model User {
-  status    UserStatus
-  posts     Post[]
   id        String     @default(uuid()) @id
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
+  status    UserStatus
+  posts     Post[]
 }
 "
 `;

--- a/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
@@ -92,28 +92,6 @@ exports[`PrismaModel > Should support adding fields 1`] = `
 `;
 
 exports[`PrismaModel > Should support adding mixins > model User {
-  email       String
-  phoneNumber String
-  id          String @default(uuid()) @id
-} 1`] = `
-"model User {
-  email       String
-  phoneNumber String
-  id          String @default(uuid()) @id
-}"
-`;
-
-exports[`PrismaModel > Should support adding mixins > model User {
-  email       String
-  phoneNumber String
-} 1`] = `
-"model User {
-  email       String
-  phoneNumber String
-}"
-`;
-
-exports[`PrismaModel > Should support adding mixins > model User {
   id          String @default(uuid()) @id
   email       String
   phoneNumber String


### PR DESCRIPTION
This should fix the order of the fields when using mixins, I basically wrapped all field setters in setImmediate. This currently passes all tests and outputs the expected schema.
@ridafkih what do you think?

Also, I removed two snapshots that were obsolete.
