### PR TITLE
feat: add types to accept "extensions"

### DIFF
--- a/lib/typings/prisma-datasource.ts
+++ b/lib/typings/prisma-datasource.ts
@@ -20,5 +20,6 @@ export interface PrismaDataSourceOptions {
     | {
         env: string;
       };
+  extensions?: string[];
   referentialIntegrity?: PrismaDataSourceReferentialIntegrity;
 }

--- a/tests/modules/PrismaSchema.spec.ts
+++ b/tests/modules/PrismaSchema.spec.ts
@@ -2,7 +2,7 @@ import { PrismaSchema } from "schemix/lib/index";
 import { describe, expect, it } from "vitest";
 
 describe("PrismaSchema", () => {
-  it("Should expect multiple generators", async () => {
+  it("Should accept multiple generators", async () => {
     const schema = new PrismaSchema(
       {
         provider: "cockroachdb",
@@ -18,6 +18,21 @@ describe("PrismaSchema", () => {
           name: "other",
         },
       ]
+    );
+
+    const asString = await schema.toString();
+    expect(asString).toMatchSnapshot();
+  });
+  it("Should accept extensions", async () => {
+    const schema = new PrismaSchema(
+      {
+        provider: "postgresql",
+        url: { env: "DATABASE_URL" },
+        extensions: ["pg_tgrm", "zombodb"],
+      },
+      {
+        provider: "prisma-client-js",
+      }
     );
 
     const asString = await schema.toString();

--- a/tests/modules/__snapshots__/PrismaSchema.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaSchema.spec.ts.snap
@@ -1,6 +1,19 @@
 // Vitest Snapshot v1
 
-exports[`PrismaSchema > Should expect multiple generators 1`] = `
+exports[`PrismaSchema > Should accept extensions 1`] = `
+"datasource database {
+  provider   = \\"postgresql\\"
+  url        = env(\\"DATABASE_URL\\")
+  extensions = [\\"pg_tgrm\\",\\"zombodb\\"]
+}
+
+generator client {
+  provider = \\"prisma-client-js\\"
+}
+"
+`;
+
+exports[`PrismaSchema > Should accept multiple generators 1`] = `
 "datasource database {
   provider = \\"cockroachdb\\"
   url      = env(\\"DATABASE_URL\\")


### PR DESCRIPTION
As requested by #52, this adds both types and tests for the "extensions" property of `PrismaDataSourceOptions`