### PR TITLE
fix: don't wrap "extensions" in quotes for key-value blocks

### DIFF
--- a/lib/util/blocks.ts
+++ b/lib/util/blocks.ts
@@ -17,6 +17,10 @@ export const parseKeyValueBlock = (
         return `  ${key.padEnd(tokenPadding)} = env("${value.env}")`;
       }
 
+      if (key === "extensions" && Array.isArray(value)) {
+        return `  ${key.padEnd(tokenPadding)} = [${value.join(", ")}]`;
+      }
+
       return typeof value === "string"
         ? `  ${key.padEnd(tokenPadding)} = "${value}"`
         : `  ${key.padEnd(tokenPadding)} = ${JSON.stringify(value)}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schemix",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Schemix allows you to programmatically create Prisma schemas using TypeScript",
   "repository": {
     "url": "https://github.com/ridafkih/schemix"

--- a/tests/modules/__snapshots__/PrismaSchema.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaSchema.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`PrismaSchema > Should accept extensions 1`] = `
 "datasource database {
   provider   = \\"postgresql\\"
   url        = env(\\"DATABASE_URL\\")
-  extensions = [\\"pg_tgrm\\",\\"zombodb\\"]
+  extensions = [pg_tgrm, zombodb]
 }
 
 generator client {


### PR DESCRIPTION
Second pull request meant to address #52 by @KrzysztofZawisla, which removes quotes from "extensions" keys in the key-value blocks 

```ts
const schema = new PrismaSchema(
  {
    provider: "postgresql",
    url: { env: "DATABASE_URL" },
    extensions: ["pg_tgrm", "zombodb"],
  },
  // ...
);
```

From test snapshot, this is the resulting extensions value.
```
datasource database {
  provider   = \\"postgresql\\"
  url        = env(\\"DATABASE_URL\\")
  extensions = [pg_tgrm, zombodb]
}
```