### PR TITLE
fix: allow shadowDatabaseUrl to be set with env key in object

### DIFF
--- a/lib/util/blocks.ts
+++ b/lib/util/blocks.ts
@@ -17,6 +17,14 @@ export const parseKeyValueBlock = (
         return `  ${key.padEnd(tokenPadding)} = env("${value.env}")`;
       }
 
+      if (
+        key === "shadowDatabaseUrl" &&
+        typeof value !== "string" &&
+        "env" in value
+      ) {
+        return `  ${key.padEnd(tokenPadding)} = env("${value.env}")`;
+      }
+
       if (key === "extensions" && Array.isArray(value)) {
         return `  ${key.padEnd(tokenPadding)} = [${value.join(", ")}]`;
       }

--- a/tests/modules/PrismaSchema.spec.ts
+++ b/tests/modules/PrismaSchema.spec.ts
@@ -38,4 +38,19 @@ describe("PrismaSchema", () => {
     const asString = await schema.toString();
     expect(asString).toMatchSnapshot();
   });
+  it("Should support shadowDatabaseUrl with environment variables", async () => {
+    const schema = new PrismaSchema(
+      {
+        provider: "postgresql",
+        url: { env: "DATABASE_URL" },
+        shadowDatabaseUrl: { env: "SHADOW_DATABASE_URL" },
+      },
+      {
+        provider: "prisma-client-js",
+      }
+    );
+
+    const asString = await schema.toString();
+    expect(asString).toMatchSnapshot();
+  });
 });

--- a/tests/modules/__snapshots__/PrismaSchema.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaSchema.spec.ts.snap
@@ -28,3 +28,16 @@ generator other {
 }
 "
 `;
+
+exports[`PrismaSchema > Should support shadowDatabaseUrl with environment variables 1`] = `
+"datasource database {
+  provider          = \\"postgresql\\"
+  url               = env(\\"DATABASE_URL\\")
+  shadowDatabaseUrl = env(\\"SHADOW_DATABASE_URL\\")
+}
+
+generator client {
+  provider = \\"prisma-client-js\\"
+}
+"
+`;


### PR DESCRIPTION
This addresses #19 by adding an explicit check for the "shadowDatabaseUrl" key and the "env" key in the supplied object.