### PR TITLE
include support for decimal precision

### DIFF
--- a/lib/modules/PrismaModel.ts
+++ b/lib/modules/PrismaModel.ts
@@ -60,6 +60,12 @@ export class PrismaModel {
   }
 
   public decimal(fieldName: string, options?: DecimalFieldOptions) {
+    if (options?.precision) {
+      const rawAttributes = options.raw?.split(" ") ?? [];
+      rawAttributes?.push(`@database.Decimal(${options.precision.join(", ")})`);
+      options.raw = rawAttributes.join(" ");
+    }
+
     return this.createField(fieldName, "Decimal", options);
   }
 

--- a/lib/typings/prisma-type-options.ts
+++ b/lib/typings/prisma-type-options.ts
@@ -75,12 +75,14 @@ export type FloatFieldOptions = (
 
 export type DecimalFieldOptions = (
   | {
+      precision?: [number, number];
       default?: number;
       optional?: true;
       unique?: true;
       list?: never;
     }
   | {
+      precision?: [number, number];
       default?: never;
       optional?: never;
       unique?: never;

--- a/lib/util/options.ts
+++ b/lib/util/options.ts
@@ -21,6 +21,7 @@ export const handleScalarOptions = <T extends FieldOptions>(
   field: PrismaScalarField,
   options: T
 ) => {
+  const keyBlacklist: string[] = ["precision"];
   const propertyMap: Record<string, keyof PrismaScalarField> = {
     id: "setAsId",
     optional: "setOptional",
@@ -32,8 +33,9 @@ export const handleScalarOptions = <T extends FieldOptions>(
     raw: "setRawAttributes",
   };
 
-  for (const [key, value] of Object.entries(options))
-    field[propertyMap[key]](value);
+  for (const [key, value] of Object.entries(options)) {
+    if (!keyBlacklist.includes(key)) field[propertyMap[key]](value);
+  }
 };
 
 /**

--- a/tests/modules/PrismaModel.spec.ts
+++ b/tests/modules/PrismaModel.spec.ts
@@ -76,6 +76,17 @@ describe("PrismaModel", () => {
     const asString = await model.toString();
     expect(asString).toMatchSnapshot();
   });
+  it("Should allow setting precision of decimals through the precision option on the field", async () => {
+    const model = new PrismaModel("User")
+      .string("id", { default: { uuid: true }, id: true })
+      .decimal("longitude", { precision: [10, 8] })
+      .decimal("latitude", { precision: [10, 8] })
+      .dateTime("updatedAt", { updatedAt: true })
+      .dateTime("createdAt", { default: { now: true } });
+
+    const asString = await model.toString();
+    expect(asString).toMatchSnapshot();
+  });
   it("Should allow setting defaults for Json fields", async () => {
     const model = new PrismaModel("User")
       .string("id", { default: { uuid: true }, id: true })

--- a/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
@@ -65,6 +65,16 @@ exports[`PrismaModel > Should allow setting defaults for Json fields > model Use
 }"
 `;
 
+exports[`PrismaModel > Should allow setting precision of decimals through the precision option on the field 1`] = `
+"model User {
+  id        String   @default(uuid()) @id
+  longitude Decimal  @database.Decimal(10, 8)
+  latitude  Decimal  @database.Decimal(10, 8)
+  updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now())
+}"
+`;
+
 exports[`PrismaModel > Should support adding a map > model User {
   id String @default(uuid()) @id
 


### PR DESCRIPTION
Supports the request made in #28 to add decimal precisions as a first-class property of the library.