### PR TITLE
#65 Add 'relationMode' attribute as an option to datasource

### DIFF
--- a/lib/typings/prisma-datasource.ts
+++ b/lib/typings/prisma-datasource.ts
@@ -6,7 +6,7 @@ export type PrismaDataSourceProvider =
   | "mongodb"
   | "cockroachdb";
 
-export type PrismaDataSourceReferentialIntegrity = "foreignKeys" | "prisma";
+export type PrismaDataSourceRelationMode = "foreignKeys" | "prisma";
 
 export interface PrismaDataSourceOptions {
   provider: PrismaDataSourceProvider;
@@ -21,5 +21,6 @@ export interface PrismaDataSourceOptions {
         env: string;
       };
   extensions?: string[];
-  referentialIntegrity?: PrismaDataSourceReferentialIntegrity;
+  referentialIntegrity?: PrismaDataSourceRelationMode;
+  relationMode?: PrismaDataSourceRelationMode;
 }

--- a/tests/__snapshots__/index.spec.ts.snap
+++ b/tests/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,31 @@
 // Vitest Snapshot v1
 
+exports[`index > Can use the \`referentialIntegrity\` attributwe 1`] = `
+"datasource database {
+  provider             = \\"cockroachdb\\"
+  url                  = env(\\"DATABASE_URL\\")
+  referentialIntegrity = \\"prisma\\"
+}
+
+generator client {
+  provider = \\"prisma-client-js\\"
+}
+"
+`;
+
+exports[`index > Can use the \`relationMode\` attributwe 1`] = `
+"datasource database {
+  provider     = \\"cockroachdb\\"
+  url          = env(\\"DATABASE_URL\\")
+  relationMode = \\"prisma\\"
+}
+
+generator client {
+  provider = \\"prisma-client-js\\"
+}
+"
+`;
+
 exports[`index > Should allow to create schemas from a pre-defined folder structure 1`] = `
 "datasource database {
   provider = \\"cockroachdb\\"

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -18,4 +18,36 @@ describe("index", () => {
     const asString = await schema.toString();
     expect(asString).toMatchSnapshot();
   });
+  it("Can use the `relationMode` attributwe", async () => {
+    const schema = createSchema({
+      datasource: {
+        provider: "cockroachdb",
+        url: { env: "DATABASE_URL" },
+        relationMode: "prisma",
+      },
+      generator: {
+        provider: "prisma-client-js",
+      },
+      basePath: join(__dirname, "__schema__"),
+    });
+
+    const asString = await schema.toString();
+    expect(asString).toMatchSnapshot();
+  });
+  it("Can use the `referentialIntegrity` attributwe", async () => {
+    const schema = createSchema({
+      datasource: {
+        provider: "cockroachdb",
+        url: { env: "DATABASE_URL" },
+        referentialIntegrity: "prisma",
+      },
+      generator: {
+        provider: "prisma-client-js",
+      },
+      basePath: join(__dirname, "__schema__"),
+    });
+
+    const asString = await schema.toString();
+    expect(asString).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Fixes an issue referenced in #65, as Prisma has renamed the `referentialIntegrity` attribute name.