### PR TITLE
Support @ignore Prisma directive

### DIFF
--- a/examples/standard-usage/README.md
+++ b/examples/standard-usage/README.md
@@ -45,6 +45,7 @@ model User {
   friendRelations User[]   @relation(name: "friends")
   email           String
   fullName        String
+  age             Int      @ignore
 
   @@id([email])
 }

--- a/examples/standard-usage/models/User.model.ts
+++ b/examples/standard-usage/models/User.model.ts
@@ -13,6 +13,7 @@ export default createModel((UserModel) => {
     .relation("friendRelations", UserModel, { list: true, name: "friends" })
     .string("email")
     .string("fullName")
+    .int("age", { ignore: true })
     .enum("role", UserRoleEnum)
     .map("user")
     .id({ fields: ["email"] });

--- a/examples/standard-usage/schema.prisma
+++ b/examples/standard-usage/schema.prisma
@@ -47,6 +47,7 @@ model User {
   friendRelations User[]   @relation(name: "friends")
   email           String
   fullName        String
+  age             Int      @ignore
   role            UserRole
 
   @@map("user")

--- a/lib/modules/PrismaScalarField.ts
+++ b/lib/modules/PrismaScalarField.ts
@@ -65,6 +65,11 @@ export class PrismaScalarField {
     return this;
   }
 
+  public setIgnore() {
+    this.attributes.set("ignore", "@ignore");
+    return this;
+  }
+
   public mapTo(fieldName: string) {
     this.attributes.set("map", `@map("${fieldName}")`);
     return this;

--- a/lib/typings/prisma-field.ts
+++ b/lib/typings/prisma-field.ts
@@ -18,6 +18,7 @@ export type PrismaFieldAttribute =
   | "@id"
   | "@updatedAt"
   | `@map("${string}")`
-  | `@default(${string})`;
+  | `@default(${string})`
+  | "@ignore";
 
 export type PrismaFieldModifier = "?" | "[]" | "";

--- a/lib/typings/prisma-type-options.ts
+++ b/lib/typings/prisma-type-options.ts
@@ -5,6 +5,7 @@ export type DefaultFieldOptions = {
   comments?: Comment[];
   map?: string;
   raw?: string;
+  ignore?: boolean;
 };
 
 export type StringFieldOptions = (

--- a/lib/util/options.ts
+++ b/lib/util/options.ts
@@ -32,6 +32,7 @@ export const handleScalarOptions = <T extends FieldOptions>(
     updatedAt: "setToUpdatedAt",
     raw: "setRawAttributes",
     comments: "setComments",
+    ignore: "setIgnore",
   };
 
   for (const [key, value] of Object.entries(options)) {

--- a/tests/modules/PrismaModel.spec.ts
+++ b/tests/modules/PrismaModel.spec.ts
@@ -256,6 +256,16 @@ describe("PrismaModel", () => {
       .string("phoneNumber");
 
     const asString = await model.toString();
-    expect(asString).toMatchSnapshot(asString);
+    expect(asString).toMatchSnapshot();
+  });
+
+  it("Should support ignore directive", async () => {
+    const model = new PrismaModel("User")
+      .string("id", { default: { uuid: true }, id: true })
+      .string("email")
+      .string("phoneNumber", { ignore: true });
+
+    const asString = await model.toString();
+    expect(asString).toMatchSnapshot();
   });
 });

--- a/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
+++ b/tests/modules/__snapshots__/PrismaModel.spec.ts.snap
@@ -105,15 +105,7 @@ exports[`PrismaModel > Should allow setting precision of decimals through the pr
 }"
 `;
 
-exports[`PrismaModel > Should inherit comments from mixins > // This is a comment on the User model
-// This is a comment on the mixin
-model User {
-  // This is a comment on the id field
-  /// @Field()
-  id          String @id @default(uuid())
-  email       String
-  phoneNumber String
-} 1`] = `
+exports[`PrismaModel > Should inherit comments from mixins 1`] = `
 "// This is a comment on the User model
 // This is a comment on the mixin
 model User {
@@ -184,6 +176,14 @@ exports[`PrismaModel > Should support every scalar field type 1`] = `
   boolean  Boolean
   dateTime DateTime
   json     Json
+}"
+`;
+
+exports[`PrismaModel > Should support ignore directive 1`] = `
+"model User {
+  id          String @default(uuid()) @id
+  email       String
+  phoneNumber String @ignore
 }"
 `;
 


### PR DESCRIPTION
Noticed the [@ignore](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#ignore) directive is not supported and this is a feature we want to use.

Hopefully everything which needs updating has been done so, please let me know if not.